### PR TITLE
feat: update two charts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @catalystsquad/engineers
+* @catalystcommunity/Core

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: crazy-max/ghaction-dump-context@v1
-      - uses: catalystsquad/action-validate-conventional-commits-pr@v1
+      - uses: catalystcommunity/action-validate-conventional-commits-pr@v1
   validate-chart:
     if: ${{ !startsWith( github.head_ref, 'automated-code-release' ) }}
     name: Validate Chart
     runs-on: ubuntu-latest
     steps:
       - uses: crazy-max/ghaction-dump-context@v1
-      - uses: catalystsquad/action-validate-helm-chart@v1
+      - uses: catalystcommunity/action-validate-helm-chart@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,6 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: catalystsquad/action-release-helm-chart@v2
+      - uses: catalystcommunity/action-release-helm-chart@v2
         with:
           token: ${{ secrets.AUTOMATION_PAT }}

--- a/.github/workflows/upload-chart.yaml
+++ b/.github/workflows/upload-chart.yaml
@@ -10,6 +10,6 @@ jobs:
       - name: Dump Context
         uses: crazy-max/ghaction-dump-context@v1
       - name: Push Chart
-        uses: catalystsquad/action-upload-chart-git@v1
+        uses: catalystcommunity/action-upload-chart-git@v1
         with:
           token: ${{ secrets.AUTOMATION_PAT }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# [2.2.0-alpha.1](https://github.com/catalystcommunity/chart-platform-services/compare/v2.1.1...v2.2.0-alpha.1) (2025-01-13)
+
+
+### Bug Fixes
+
+* move to catalystcommunity ([b4602b7](https://github.com/catalystcommunity/chart-platform-services/commit/b4602b7c1993d7784daa3fc74fcbfbbd7396503f))
+
+
+### Features
+
+* switch contour to updated oci registry ([#72](https://github.com/catalystcommunity/chart-platform-services/issues/72)) ([ff4ea85](https://github.com/catalystcommunity/chart-platform-services/commit/ff4ea85aef796913af5bd0c895cae10bea4f69ec))
+
 ## [2.1.1](https://github.com/catalystcommunity/chart-platform-services/compare/v2.1.0...v2.1.1) (2024-03-04)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,535 +1,535 @@
-## [2.1.1](https://github.com/catalystsquad/chart-platform-services/compare/v2.1.0...v2.1.1) (2024-03-04)
+## [2.1.1](https://github.com/catalystcommunity/chart-platform-services/compare/v2.1.0...v2.1.1) (2024-03-04)
 
 
 ### Bug Fixes
 
-* add new dashboard, pod resource requests by node ([#69](https://github.com/catalystsquad/chart-platform-services/issues/69)) ([2254432](https://github.com/catalystsquad/chart-platform-services/commit/2254432b4831ccfb91bca9bb241ad5f8dddbdd77))
-* add view clusterrolebinding ([#70](https://github.com/catalystsquad/chart-platform-services/issues/70)) ([89bdbc8](https://github.com/catalystsquad/chart-platform-services/commit/89bdbc83cdd49da6c829abbafdb66a2657a1087a))
-* quote wildcard cert commonName ([#68](https://github.com/catalystsquad/chart-platform-services/issues/68)) ([d0b7b0c](https://github.com/catalystsquad/chart-platform-services/commit/d0b7b0caa80ede0a11026ae812732423f50f4425))
+* add new dashboard, pod resource requests by node ([#69](https://github.com/catalystcommunity/chart-platform-services/issues/69)) ([2254432](https://github.com/catalystcommunity/chart-platform-services/commit/2254432b4831ccfb91bca9bb241ad5f8dddbdd77))
+* add view clusterrolebinding ([#70](https://github.com/catalystcommunity/chart-platform-services/issues/70)) ([89bdbc8](https://github.com/catalystcommunity/chart-platform-services/commit/89bdbc83cdd49da6c829abbafdb66a2657a1087a))
+* quote wildcard cert commonName ([#68](https://github.com/catalystcommunity/chart-platform-services/issues/68)) ([d0b7b0c](https://github.com/catalystcommunity/chart-platform-services/commit/d0b7b0caa80ede0a11026ae812732423f50f4425))
 
-## [2.1.1-alpha.3](https://github.com/catalystsquad/chart-platform-services/compare/v2.1.1-alpha.2...v2.1.1-alpha.3) (2024-03-04)
-
-
-### Bug Fixes
-
-* add view clusterrolebinding ([#70](https://github.com/catalystsquad/chart-platform-services/issues/70)) ([89bdbc8](https://github.com/catalystsquad/chart-platform-services/commit/89bdbc83cdd49da6c829abbafdb66a2657a1087a))
-
-## [2.1.1-alpha.2](https://github.com/catalystsquad/chart-platform-services/compare/v2.1.1-alpha.1...v2.1.1-alpha.2) (2023-08-21)
+## [2.1.1-alpha.3](https://github.com/catalystcommunity/chart-platform-services/compare/v2.1.1-alpha.2...v2.1.1-alpha.3) (2024-03-04)
 
 
 ### Bug Fixes
 
-* add new dashboard, pod resource requests by node ([#69](https://github.com/catalystsquad/chart-platform-services/issues/69)) ([2254432](https://github.com/catalystsquad/chart-platform-services/commit/2254432b4831ccfb91bca9bb241ad5f8dddbdd77))
+* add view clusterrolebinding ([#70](https://github.com/catalystcommunity/chart-platform-services/issues/70)) ([89bdbc8](https://github.com/catalystcommunity/chart-platform-services/commit/89bdbc83cdd49da6c829abbafdb66a2657a1087a))
 
-## [2.1.1-alpha.1](https://github.com/catalystsquad/chart-platform-services/compare/v2.1.0...v2.1.1-alpha.1) (2023-08-01)
-
-
-### Bug Fixes
-
-* quote wildcard cert commonName ([#68](https://github.com/catalystsquad/chart-platform-services/issues/68)) ([d0b7b0c](https://github.com/catalystsquad/chart-platform-services/commit/d0b7b0caa80ede0a11026ae812732423f50f4425))
-
-# [2.1.0](https://github.com/catalystsquad/chart-platform-services/compare/v2.0.0...v2.1.0) (2023-05-26)
+## [2.1.1-alpha.2](https://github.com/catalystcommunity/chart-platform-services/compare/v2.1.1-alpha.1...v2.1.1-alpha.2) (2023-08-21)
 
 
 ### Bug Fixes
 
-* add gp3 storage class ([#64](https://github.com/catalystsquad/chart-platform-services/issues/64)) ([8cfc51b](https://github.com/catalystsquad/chart-platform-services/commit/8cfc51b87daa813f2372182279d5d535c63bc5e5))
+* add new dashboard, pod resource requests by node ([#69](https://github.com/catalystcommunity/chart-platform-services/issues/69)) ([2254432](https://github.com/catalystcommunity/chart-platform-services/commit/2254432b4831ccfb91bca9bb241ad5f8dddbdd77))
+
+## [2.1.1-alpha.1](https://github.com/catalystcommunity/chart-platform-services/compare/v2.1.0...v2.1.1-alpha.1) (2023-08-01)
+
+
+### Bug Fixes
+
+* quote wildcard cert commonName ([#68](https://github.com/catalystcommunity/chart-platform-services/issues/68)) ([d0b7b0c](https://github.com/catalystcommunity/chart-platform-services/commit/d0b7b0caa80ede0a11026ae812732423f50f4425))
+
+# [2.1.0](https://github.com/catalystcommunity/chart-platform-services/compare/v2.0.0...v2.1.0) (2023-05-26)
+
+
+### Bug Fixes
+
+* add gp3 storage class ([#64](https://github.com/catalystcommunity/chart-platform-services/issues/64)) ([8cfc51b](https://github.com/catalystcommunity/chart-platform-services/commit/8cfc51b87daa813f2372182279d5d535c63bc5e5))
 
 
 ### Features
 
-* add external snapshotter ([#65](https://github.com/catalystsquad/chart-platform-services/issues/65)) ([311e47e](https://github.com/catalystsquad/chart-platform-services/commit/311e47e04221639e1ce24c1ffd83ccbf17ee7d90))
+* add external snapshotter ([#65](https://github.com/catalystcommunity/chart-platform-services/issues/65)) ([311e47e](https://github.com/catalystcommunity/chart-platform-services/commit/311e47e04221639e1ce24c1ffd83ccbf17ee7d90))
 
-# [2.1.0-alpha.1](https://github.com/catalystsquad/chart-platform-services/compare/v2.0.1-alpha.1...v2.1.0-alpha.1) (2023-05-26)
-
-
-### Features
-
-* add external snapshotter ([#65](https://github.com/catalystsquad/chart-platform-services/issues/65)) ([311e47e](https://github.com/catalystsquad/chart-platform-services/commit/311e47e04221639e1ce24c1ffd83ccbf17ee7d90))
-
-## [2.0.1-alpha.1](https://github.com/catalystsquad/chart-platform-services/compare/v2.0.0...v2.0.1-alpha.1) (2023-05-25)
-
-
-### Bug Fixes
-
-* add gp3 storage class ([#64](https://github.com/catalystsquad/chart-platform-services/issues/64)) ([8cfc51b](https://github.com/catalystsquad/chart-platform-services/commit/8cfc51b87daa813f2372182279d5d535c63bc5e5))
-
-# [2.0.0](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.1...v2.0.0) (2023-03-21)
-
-
-### Bug Fixes
-
-* ebs csi chart version ([#61](https://github.com/catalystsquad/chart-platform-services/issues/61)) ([13660fb](https://github.com/catalystsquad/chart-platform-services/commit/13660fbce75697b7684654ef5e4d7d30e220c580))
-* ignore linkerd crd changes ([#59](https://github.com/catalystsquad/chart-platform-services/issues/59)) ([8bbc604](https://github.com/catalystsquad/chart-platform-services/commit/8bbc60480fde8238e3218b089a4d7f672c2a67ce))
-* upgrade linkerd viz, jaeger charts ([#62](https://github.com/catalystsquad/chart-platform-services/issues/62)) ([b571899](https://github.com/catalystsquad/chart-platform-services/commit/b5718996906d6382f5b8cd75d570b949b97f272f))
+# [2.1.0-alpha.1](https://github.com/catalystcommunity/chart-platform-services/compare/v2.0.1-alpha.1...v2.1.0-alpha.1) (2023-05-26)
 
 
 ### Features
 
-* add aws ebs csi driver ([#60](https://github.com/catalystsquad/chart-platform-services/issues/60)) ([45d7305](https://github.com/catalystsquad/chart-platform-services/commit/45d7305759acb8e5c53bd03d2c32fde3f4046f63))
-* add aws-ecr-creds and the zalando postgres-operator ([#56](https://github.com/catalystsquad/chart-platform-services/issues/56)) ([747ee50](https://github.com/catalystsquad/chart-platform-services/commit/747ee50463d9095aaeac6e1aba941a2389ca556d))
-* upgrade helm charts to support k8s 1.25 api ([#57](https://github.com/catalystsquad/chart-platform-services/issues/57)) ([eedc2f1](https://github.com/catalystsquad/chart-platform-services/commit/eedc2f144e8f1e0232f25df72a239de9de0f8668))
+* add external snapshotter ([#65](https://github.com/catalystcommunity/chart-platform-services/issues/65)) ([311e47e](https://github.com/catalystcommunity/chart-platform-services/commit/311e47e04221639e1ce24c1ffd83ccbf17ee7d90))
+
+## [2.0.1-alpha.1](https://github.com/catalystcommunity/chart-platform-services/compare/v2.0.0...v2.0.1-alpha.1) (2023-05-25)
+
+
+### Bug Fixes
+
+* add gp3 storage class ([#64](https://github.com/catalystcommunity/chart-platform-services/issues/64)) ([8cfc51b](https://github.com/catalystcommunity/chart-platform-services/commit/8cfc51b87daa813f2372182279d5d535c63bc5e5))
+
+# [2.0.0](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.1...v2.0.0) (2023-03-21)
+
+
+### Bug Fixes
+
+* ebs csi chart version ([#61](https://github.com/catalystcommunity/chart-platform-services/issues/61)) ([13660fb](https://github.com/catalystcommunity/chart-platform-services/commit/13660fbce75697b7684654ef5e4d7d30e220c580))
+* ignore linkerd crd changes ([#59](https://github.com/catalystcommunity/chart-platform-services/issues/59)) ([8bbc604](https://github.com/catalystcommunity/chart-platform-services/commit/8bbc60480fde8238e3218b089a4d7f672c2a67ce))
+* upgrade linkerd viz, jaeger charts ([#62](https://github.com/catalystcommunity/chart-platform-services/issues/62)) ([b571899](https://github.com/catalystcommunity/chart-platform-services/commit/b5718996906d6382f5b8cd75d570b949b97f272f))
+
+
+### Features
+
+* add aws ebs csi driver ([#60](https://github.com/catalystcommunity/chart-platform-services/issues/60)) ([45d7305](https://github.com/catalystcommunity/chart-platform-services/commit/45d7305759acb8e5c53bd03d2c32fde3f4046f63))
+* add aws-ecr-creds and the zalando postgres-operator ([#56](https://github.com/catalystcommunity/chart-platform-services/issues/56)) ([747ee50](https://github.com/catalystcommunity/chart-platform-services/commit/747ee50463d9095aaeac6e1aba941a2389ca556d))
+* upgrade helm charts to support k8s 1.25 api ([#57](https://github.com/catalystcommunity/chart-platform-services/issues/57)) ([eedc2f1](https://github.com/catalystcommunity/chart-platform-services/commit/eedc2f144e8f1e0232f25df72a239de9de0f8668))
 
 
 ### BREAKING CHANGES
 
 * application major version upgrades, field changes
 
-# [2.0.0-alpha.5](https://github.com/catalystsquad/chart-platform-services/compare/v2.0.0-alpha.4...v2.0.0-alpha.5) (2023-03-20)
+# [2.0.0-alpha.5](https://github.com/catalystcommunity/chart-platform-services/compare/v2.0.0-alpha.4...v2.0.0-alpha.5) (2023-03-20)
 
 
 ### Bug Fixes
 
-* upgrade linkerd viz, jaeger charts ([#62](https://github.com/catalystsquad/chart-platform-services/issues/62)) ([b571899](https://github.com/catalystsquad/chart-platform-services/commit/b5718996906d6382f5b8cd75d570b949b97f272f))
+* upgrade linkerd viz, jaeger charts ([#62](https://github.com/catalystcommunity/chart-platform-services/issues/62)) ([b571899](https://github.com/catalystcommunity/chart-platform-services/commit/b5718996906d6382f5b8cd75d570b949b97f272f))
 
-# [2.0.0-alpha.4](https://github.com/catalystsquad/chart-platform-services/compare/v2.0.0-alpha.3...v2.0.0-alpha.4) (2023-03-16)
+# [2.0.0-alpha.4](https://github.com/catalystcommunity/chart-platform-services/compare/v2.0.0-alpha.3...v2.0.0-alpha.4) (2023-03-16)
 
 
 ### Bug Fixes
 
-* ebs csi chart version ([#61](https://github.com/catalystsquad/chart-platform-services/issues/61)) ([13660fb](https://github.com/catalystsquad/chart-platform-services/commit/13660fbce75697b7684654ef5e4d7d30e220c580))
+* ebs csi chart version ([#61](https://github.com/catalystcommunity/chart-platform-services/issues/61)) ([13660fb](https://github.com/catalystcommunity/chart-platform-services/commit/13660fbce75697b7684654ef5e4d7d30e220c580))
 
-# [2.0.0-alpha.3](https://github.com/catalystsquad/chart-platform-services/compare/v2.0.0-alpha.2...v2.0.0-alpha.3) (2023-03-16)
+# [2.0.0-alpha.3](https://github.com/catalystcommunity/chart-platform-services/compare/v2.0.0-alpha.2...v2.0.0-alpha.3) (2023-03-16)
 
 
 ### Features
 
-* add aws ebs csi driver ([#60](https://github.com/catalystsquad/chart-platform-services/issues/60)) ([45d7305](https://github.com/catalystsquad/chart-platform-services/commit/45d7305759acb8e5c53bd03d2c32fde3f4046f63))
+* add aws ebs csi driver ([#60](https://github.com/catalystcommunity/chart-platform-services/issues/60)) ([45d7305](https://github.com/catalystcommunity/chart-platform-services/commit/45d7305759acb8e5c53bd03d2c32fde3f4046f63))
 
-# [2.0.0-alpha.2](https://github.com/catalystsquad/chart-platform-services/compare/v2.0.0-alpha.1...v2.0.0-alpha.2) (2023-03-06)
+# [2.0.0-alpha.2](https://github.com/catalystcommunity/chart-platform-services/compare/v2.0.0-alpha.1...v2.0.0-alpha.2) (2023-03-06)
 
 
 ### Bug Fixes
 
-* ignore linkerd crd changes ([#59](https://github.com/catalystsquad/chart-platform-services/issues/59)) ([8bbc604](https://github.com/catalystsquad/chart-platform-services/commit/8bbc60480fde8238e3218b089a4d7f672c2a67ce))
+* ignore linkerd crd changes ([#59](https://github.com/catalystcommunity/chart-platform-services/issues/59)) ([8bbc604](https://github.com/catalystcommunity/chart-platform-services/commit/8bbc60480fde8238e3218b089a4d7f672c2a67ce))
 
-# [2.0.0-alpha.1](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.1...v2.0.0-alpha.1) (2023-03-06)
+# [2.0.0-alpha.1](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.1...v2.0.0-alpha.1) (2023-03-06)
 
 
 ### Features
 
-* add aws-ecr-creds and the zalando postgres-operator ([#56](https://github.com/catalystsquad/chart-platform-services/issues/56)) ([747ee50](https://github.com/catalystsquad/chart-platform-services/commit/747ee50463d9095aaeac6e1aba941a2389ca556d))
-* upgrade helm charts to support k8s 1.25 api ([#57](https://github.com/catalystsquad/chart-platform-services/issues/57)) ([eedc2f1](https://github.com/catalystsquad/chart-platform-services/commit/eedc2f144e8f1e0232f25df72a239de9de0f8668))
+* add aws-ecr-creds and the zalando postgres-operator ([#56](https://github.com/catalystcommunity/chart-platform-services/issues/56)) ([747ee50](https://github.com/catalystcommunity/chart-platform-services/commit/747ee50463d9095aaeac6e1aba941a2389ca556d))
+* upgrade helm charts to support k8s 1.25 api ([#57](https://github.com/catalystcommunity/chart-platform-services/issues/57)) ([eedc2f1](https://github.com/catalystcommunity/chart-platform-services/commit/eedc2f144e8f1e0232f25df72a239de9de0f8668))
 
 
 ### BREAKING CHANGES
 
 * application major version upgrades, field changes
 
-## [1.0.1](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0...v1.0.1) (2022-12-19)
+## [1.0.1](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0...v1.0.1) (2022-12-19)
 
 
 ### Bug Fixes
 
-* metrics-server extra args ([#53](https://github.com/catalystsquad/chart-platform-services/issues/53)) ([f6181bb](https://github.com/catalystsquad/chart-platform-services/commit/f6181bbe3d39ae066d013625f2e2f85f66c1fde6))
-* new dashboard for persistent volume claim usage by cluster ([#51](https://github.com/catalystsquad/chart-platform-services/issues/51)) ([7d16d1b](https://github.com/catalystsquad/chart-platform-services/commit/7d16d1beee084f9e2d86ef2a30efb9790cd6d79a))
-* pvc autoresizer default prometheusURL ([#50](https://github.com/catalystsquad/chart-platform-services/issues/50)) ([6da1c5b](https://github.com/catalystsquad/chart-platform-services/commit/6da1c5b6660017262aaa171c13672354e0b94dbb))
-* Release ([8141e90](https://github.com/catalystsquad/chart-platform-services/commit/8141e907cc4aa451488f97a85d087316e1caaae0))
-* upgrade helm chart versions that were removed from bitnami repo ([#52](https://github.com/catalystsquad/chart-platform-services/issues/52)) ([c96a5c8](https://github.com/catalystsquad/chart-platform-services/commit/c96a5c8b3055af092a3b1eb53c3802eb1916a188))
-* upgrade postgres bitnami chart version ([#54](https://github.com/catalystsquad/chart-platform-services/issues/54)) ([121fe0a](https://github.com/catalystsquad/chart-platform-services/commit/121fe0a32e8d7d0bec87b1dd9ba4772136a806f0))
-* upgrade the grafana chart ([#49](https://github.com/catalystsquad/chart-platform-services/issues/49)) ([6fde7ba](https://github.com/catalystsquad/chart-platform-services/commit/6fde7ba5acf2dcf10efe2689a962797974bc7880))
+* metrics-server extra args ([#53](https://github.com/catalystcommunity/chart-platform-services/issues/53)) ([f6181bb](https://github.com/catalystcommunity/chart-platform-services/commit/f6181bbe3d39ae066d013625f2e2f85f66c1fde6))
+* new dashboard for persistent volume claim usage by cluster ([#51](https://github.com/catalystcommunity/chart-platform-services/issues/51)) ([7d16d1b](https://github.com/catalystcommunity/chart-platform-services/commit/7d16d1beee084f9e2d86ef2a30efb9790cd6d79a))
+* pvc autoresizer default prometheusURL ([#50](https://github.com/catalystcommunity/chart-platform-services/issues/50)) ([6da1c5b](https://github.com/catalystcommunity/chart-platform-services/commit/6da1c5b6660017262aaa171c13672354e0b94dbb))
+* Release ([8141e90](https://github.com/catalystcommunity/chart-platform-services/commit/8141e907cc4aa451488f97a85d087316e1caaae0))
+* upgrade helm chart versions that were removed from bitnami repo ([#52](https://github.com/catalystcommunity/chart-platform-services/issues/52)) ([c96a5c8](https://github.com/catalystcommunity/chart-platform-services/commit/c96a5c8b3055af092a3b1eb53c3802eb1916a188))
+* upgrade postgres bitnami chart version ([#54](https://github.com/catalystcommunity/chart-platform-services/issues/54)) ([121fe0a](https://github.com/catalystcommunity/chart-platform-services/commit/121fe0a32e8d7d0bec87b1dd9ba4772136a806f0))
+* upgrade the grafana chart ([#49](https://github.com/catalystcommunity/chart-platform-services/issues/49)) ([6fde7ba](https://github.com/catalystcommunity/chart-platform-services/commit/6fde7ba5acf2dcf10efe2689a962797974bc7880))
 
-## [1.0.1-alpha.6](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.1-alpha.5...v1.0.1-alpha.6) (2022-12-19)
-
-
-### Bug Fixes
-
-* upgrade postgres bitnami chart version ([#54](https://github.com/catalystsquad/chart-platform-services/issues/54)) ([121fe0a](https://github.com/catalystsquad/chart-platform-services/commit/121fe0a32e8d7d0bec87b1dd9ba4772136a806f0))
-
-## [1.0.1-alpha.5](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.1-alpha.4...v1.0.1-alpha.5) (2022-12-19)
+## [1.0.1-alpha.6](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.1-alpha.5...v1.0.1-alpha.6) (2022-12-19)
 
 
 ### Bug Fixes
 
-* metrics-server extra args ([#53](https://github.com/catalystsquad/chart-platform-services/issues/53)) ([f6181bb](https://github.com/catalystsquad/chart-platform-services/commit/f6181bbe3d39ae066d013625f2e2f85f66c1fde6))
+* upgrade postgres bitnami chart version ([#54](https://github.com/catalystcommunity/chart-platform-services/issues/54)) ([121fe0a](https://github.com/catalystcommunity/chart-platform-services/commit/121fe0a32e8d7d0bec87b1dd9ba4772136a806f0))
 
-## [1.0.1-alpha.4](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.1-alpha.3...v1.0.1-alpha.4) (2022-12-19)
-
-
-### Bug Fixes
-
-* upgrade helm chart versions that were removed from bitnami repo ([#52](https://github.com/catalystsquad/chart-platform-services/issues/52)) ([c96a5c8](https://github.com/catalystsquad/chart-platform-services/commit/c96a5c8b3055af092a3b1eb53c3802eb1916a188))
-
-## [1.0.1-alpha.3](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.1-alpha.2...v1.0.1-alpha.3) (2022-11-14)
+## [1.0.1-alpha.5](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.1-alpha.4...v1.0.1-alpha.5) (2022-12-19)
 
 
 ### Bug Fixes
 
-* new dashboard for persistent volume claim usage by cluster ([#51](https://github.com/catalystsquad/chart-platform-services/issues/51)) ([7d16d1b](https://github.com/catalystsquad/chart-platform-services/commit/7d16d1beee084f9e2d86ef2a30efb9790cd6d79a))
+* metrics-server extra args ([#53](https://github.com/catalystcommunity/chart-platform-services/issues/53)) ([f6181bb](https://github.com/catalystcommunity/chart-platform-services/commit/f6181bbe3d39ae066d013625f2e2f85f66c1fde6))
 
-## [1.0.1-alpha.2](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.1-alpha.1...v1.0.1-alpha.2) (2022-11-14)
-
-
-### Bug Fixes
-
-* pvc autoresizer default prometheusURL ([#50](https://github.com/catalystsquad/chart-platform-services/issues/50)) ([6da1c5b](https://github.com/catalystsquad/chart-platform-services/commit/6da1c5b6660017262aaa171c13672354e0b94dbb))
-
-## [1.0.1-alpha.1](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0...v1.0.1-alpha.1) (2022-10-21)
+## [1.0.1-alpha.4](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.1-alpha.3...v1.0.1-alpha.4) (2022-12-19)
 
 
 ### Bug Fixes
 
-* upgrade the grafana chart ([#49](https://github.com/catalystsquad/chart-platform-services/issues/49)) ([6fde7ba](https://github.com/catalystsquad/chart-platform-services/commit/6fde7ba5acf2dcf10efe2689a962797974bc7880))
+* upgrade helm chart versions that were removed from bitnami repo ([#52](https://github.com/catalystcommunity/chart-platform-services/issues/52)) ([c96a5c8](https://github.com/catalystcommunity/chart-platform-services/commit/c96a5c8b3055af092a3b1eb53c3802eb1916a188))
+
+## [1.0.1-alpha.3](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.1-alpha.2...v1.0.1-alpha.3) (2022-11-14)
+
+
+### Bug Fixes
+
+* new dashboard for persistent volume claim usage by cluster ([#51](https://github.com/catalystcommunity/chart-platform-services/issues/51)) ([7d16d1b](https://github.com/catalystcommunity/chart-platform-services/commit/7d16d1beee084f9e2d86ef2a30efb9790cd6d79a))
+
+## [1.0.1-alpha.2](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.1-alpha.1...v1.0.1-alpha.2) (2022-11-14)
+
+
+### Bug Fixes
+
+* pvc autoresizer default prometheusURL ([#50](https://github.com/catalystcommunity/chart-platform-services/issues/50)) ([6da1c5b](https://github.com/catalystcommunity/chart-platform-services/commit/6da1c5b6660017262aaa171c13672354e0b94dbb))
+
+## [1.0.1-alpha.1](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0...v1.0.1-alpha.1) (2022-10-21)
+
+
+### Bug Fixes
+
+* upgrade the grafana chart ([#49](https://github.com/catalystcommunity/chart-platform-services/issues/49)) ([6fde7ba](https://github.com/catalystcommunity/chart-platform-services/commit/6fde7ba5acf2dcf10efe2689a962797974bc7880))
 
 # 1.0.0 (2022-08-12)
 
 
 ### Bug Fixes
 
-* add datasource auth environment variable secret ([#22](https://github.com/catalystsquad/chart-platform-services/issues/22)) ([4aa6bcf](https://github.com/catalystsquad/chart-platform-services/commit/4aa6bcf3d8f8393df372f9fca90c963b31ec31eb))
-* Add empty group so argo will stop diffing. ([#13](https://github.com/catalystsquad/chart-platform-services/issues/13)) ([b9c8f25](https://github.com/catalystsquad/chart-platform-services/commit/b9c8f2587aa4a27b1917f9b5e18e357e017b2c84))
-* add http metric dashboard panels for cortex ([#35](https://github.com/catalystsquad/chart-platform-services/issues/35)) ([9d16235](https://github.com/catalystsquad/chart-platform-services/commit/9d16235f13a40e050bea5a4446f4df20aa5092cf))
-* Add ignore differences to linkerd-jaeger and linkerd-viz ([#12](https://github.com/catalystsquad/chart-platform-services/issues/12)) ([0294c3e](https://github.com/catalystsquad/chart-platform-services/commit/0294c3eb56976a90b52ad02f167025396b839b47))
-* add index gateway panel's to loki dashboard ([#30](https://github.com/catalystsquad/chart-platform-services/issues/30)) ([bb4ad1e](https://github.com/catalystsquad/chart-platform-services/commit/bb4ad1e954100f0de27589ffdd267e2472919865))
-* Add resource requests to linkerd proxy, and contour envoy shutdown manager. Without these HPAs don't work. ([#14](https://github.com/catalystsquad/chart-platform-services/issues/14)) ([a2c0a0a](https://github.com/catalystsquad/chart-platform-services/commit/a2c0a0a75bb1191cb64c1ffb9e242a08fb96b0e3))
-* Add self signed certificate issuer, enabled by default ([#28](https://github.com/catalystsquad/chart-platform-services/issues/28)) ([bc8b440](https://github.com/catalystsquad/chart-platform-services/commit/bc8b4409aeeb13da52227a2ecfddc3c24cfa3bfb))
-* Added fusion auth and postgres for fusion auth to the chart ([#6](https://github.com/catalystsquad/chart-platform-services/issues/6)) ([e457b99](https://github.com/catalystsquad/chart-platform-services/commit/e457b998f2247a1409e0b34768358cd9dd51ffc5))
-* base64 encode secrets in grafana auth template ([#23](https://github.com/catalystsquad/chart-platform-services/issues/23)) ([fdfa191](https://github.com/catalystsquad/chart-platform-services/commit/fdfa191816f90dab758c1433ab294e1d5d74bab2))
-* change loki release name to match helm chart ([#24](https://github.com/catalystsquad/chart-platform-services/issues/24)) ([6fdcdc5](https://github.com/catalystsquad/chart-platform-services/commit/6fdcdc5f75a0314e9525d77624b38369e6b8fc0e))
-* cortex/loki auth secret namespace ([#20](https://github.com/catalystsquad/chart-platform-services/issues/20)) ([eef2b81](https://github.com/catalystsquad/chart-platform-services/commit/eef2b81bb1a8d735f4f1ef550d7887062f136285))
-* dashboard panels for cortex memcached ([#34](https://github.com/catalystsquad/chart-platform-services/issues/34)) ([6f68fdd](https://github.com/catalystsquad/chart-platform-services/commit/6f68fdddfbbc7a7cddc79c15611dfc33ada3e30a))
-* Default metrics-server apiService.create to true ([#15](https://github.com/catalystsquad/chart-platform-services/issues/15)) ([23b12ce](https://github.com/catalystsquad/chart-platform-services/commit/23b12ce992cf71d6e6aad887d2449eaf2785326e))
-* Default to not creating resources that would rotate certificates. ([#10](https://github.com/catalystsquad/chart-platform-services/issues/10)) ([0d1a8cf](https://github.com/catalystsquad/chart-platform-services/commit/0d1a8cf7998f83165ade3798563207470ed03dfa))
-* Disable sentry by default, default organizations to empty, fix wildcard cert configuration ([#2](https://github.com/catalystsquad/chart-platform-services/issues/2)) ([126372b](https://github.com/catalystsquad/chart-platform-services/commit/126372b61b5456110dd53d05c4e0950213d15726))
-* enable cortex ingester statefulSet by default ([#32](https://github.com/catalystsquad/chart-platform-services/issues/32)) ([d4cd2e3](https://github.com/catalystsquad/chart-platform-services/commit/d4cd2e363e39e33c09d18e79d06fcc9f3ae8fdca))
-* enable metrics in contour ([#17](https://github.com/catalystsquad/chart-platform-services/issues/17)) ([50c832e](https://github.com/catalystsquad/chart-platform-services/commit/50c832e24af2988865195123b5a44546cd48b97b))
-* enable retention on the loki compactor component ([#42](https://github.com/catalystsquad/chart-platform-services/issues/42)) ([bef3357](https://github.com/catalystsquad/chart-platform-services/commit/bef335726d6d0966168b2f5d3cd642857cb50939))
-* grafana datasource value reference ([#19](https://github.com/catalystsquad/chart-platform-services/issues/19)) ([0264a06](https://github.com/catalystsquad/chart-platform-services/commit/0264a066504ef910b5ce81e28d0155bb6e139d19))
-* increase loki gateway's default client max body size ([#26](https://github.com/catalystsquad/chart-platform-services/issues/26)) ([72fc52f](https://github.com/catalystsquad/chart-platform-services/commit/72fc52f7169463b15283798483c58d6a2528095f))
-* Initial commit ([#1](https://github.com/catalystsquad/chart-platform-services/issues/1)) ([d80e5ca](https://github.com/catalystsquad/chart-platform-services/commit/d80e5ca9a340b55b15f745dbdc098f621599ba82))
-* Linkerd uses helm template commands to generate certs. This happens on every sync, so it goes into a loop. This commit adds the necessary ignore differences specification to avoid an out of sync loop. ([#11](https://github.com/catalystsquad/chart-platform-services/issues/11)) ([865e29b](https://github.com/catalystsquad/chart-platform-services/commit/865e29b5316a8247bd72fcdd913410d2f31dd15d))
-* match aws default for volumeBindingMode ([#16](https://github.com/catalystsquad/chart-platform-services/issues/16)) ([ed75766](https://github.com/catalystsquad/chart-platform-services/commit/ed757662151a7815cf0e8ab32b7175bc6e3f4494))
-* **norelease:** allow merge commit for merging alpha to main ([#46](https://github.com/catalystsquad/chart-platform-services/issues/46)) ([4a7bbf5](https://github.com/catalystsquad/chart-platform-services/commit/4a7bbf5ca70c33cb7fb51802a7b248ee6d6b38b5))
-* Release ([90f4355](https://github.com/catalystsquad/chart-platform-services/commit/90f4355140e9aa118d328e8a0978c9aaa88207a2))
-* Remove cert-manager dns secret, fix solvers config. Solvers should be yaml, not a string. ([#3](https://github.com/catalystsquad/chart-platform-services/issues/3)) ([904012b](https://github.com/catalystsquad/chart-platform-services/commit/904012bd0b1dcfa4f2da32fd89ef7cf162f1aa71))
-* remove configuration for cortex query scheduler ([#33](https://github.com/catalystsquad/chart-platform-services/issues/33)) ([10e9765](https://github.com/catalystsquad/chart-platform-services/commit/10e9765eeba3da7f078f7095e995bcf08c67b160))
-* remove htpasswd generation for grafana datasource access ([#36](https://github.com/catalystsquad/chart-platform-services/issues/36)) ([474a38c](https://github.com/catalystsquad/chart-platform-services/commit/474a38c8d7c7cec1777a674087be360b70ed3857))
-* Remove trustanchor.crt value in favor of existing chart value named identityTrustAnchorsPEM. ([#5](https://github.com/catalystsquad/chart-platform-services/issues/5)) ([46d7ddc](https://github.com/catalystsquad/chart-platform-services/commit/46d7ddcb3cd253a1eeaaebdb0245f864595b22ac))
-* rename cortex/loki dashboards to organize better with mixin ([#29](https://github.com/catalystsquad/chart-platform-services/issues/29)) ([8193aa6](https://github.com/catalystsquad/chart-platform-services/commit/8193aa60cb9c8664836bb0c0d9a4bcef9e79c0ea))
-* Update contour chart version ([#31](https://github.com/catalystsquad/chart-platform-services/issues/31)) ([0401076](https://github.com/catalystsquad/chart-platform-services/commit/040107611423dcf1f7191f96db4cc506a089e974))
-* upgrade loki helm chart, remove bug workaround ([#40](https://github.com/catalystsquad/chart-platform-services/issues/40)) ([e49a5c7](https://github.com/catalystsquad/chart-platform-services/commit/e49a5c71a9fdb871c082ccae99a6036c73b24e9f))
-* Use pipes to insert cert data as a multiline string ([#8](https://github.com/catalystsquad/chart-platform-services/issues/8)) ([9f51f99](https://github.com/catalystsquad/chart-platform-services/commit/9f51f99c0baa5da40d39d39c24accb9977c54138))
-* Use stringData for cert pem because the linkerd chart requires it as a string for a configmap, but we need it in a secret for the trust anchor ([#9](https://github.com/catalystsquad/chart-platform-services/issues/9)) ([e0605c3](https://github.com/catalystsquad/chart-platform-services/commit/e0605c387b37f175813d88337eab37d0af79e389))
-* Use stringData not data, the cert and key should no longer be base64 encoded ([#7](https://github.com/catalystsquad/chart-platform-services/issues/7)) ([ee37b80](https://github.com/catalystsquad/chart-platform-services/commit/ee37b80f9f6ede27a9850641e0cf5b48fcfb2d4d))
+* add datasource auth environment variable secret ([#22](https://github.com/catalystcommunity/chart-platform-services/issues/22)) ([4aa6bcf](https://github.com/catalystcommunity/chart-platform-services/commit/4aa6bcf3d8f8393df372f9fca90c963b31ec31eb))
+* Add empty group so argo will stop diffing. ([#13](https://github.com/catalystcommunity/chart-platform-services/issues/13)) ([b9c8f25](https://github.com/catalystcommunity/chart-platform-services/commit/b9c8f2587aa4a27b1917f9b5e18e357e017b2c84))
+* add http metric dashboard panels for cortex ([#35](https://github.com/catalystcommunity/chart-platform-services/issues/35)) ([9d16235](https://github.com/catalystcommunity/chart-platform-services/commit/9d16235f13a40e050bea5a4446f4df20aa5092cf))
+* Add ignore differences to linkerd-jaeger and linkerd-viz ([#12](https://github.com/catalystcommunity/chart-platform-services/issues/12)) ([0294c3e](https://github.com/catalystcommunity/chart-platform-services/commit/0294c3eb56976a90b52ad02f167025396b839b47))
+* add index gateway panel's to loki dashboard ([#30](https://github.com/catalystcommunity/chart-platform-services/issues/30)) ([bb4ad1e](https://github.com/catalystcommunity/chart-platform-services/commit/bb4ad1e954100f0de27589ffdd267e2472919865))
+* Add resource requests to linkerd proxy, and contour envoy shutdown manager. Without these HPAs don't work. ([#14](https://github.com/catalystcommunity/chart-platform-services/issues/14)) ([a2c0a0a](https://github.com/catalystcommunity/chart-platform-services/commit/a2c0a0a75bb1191cb64c1ffb9e242a08fb96b0e3))
+* Add self signed certificate issuer, enabled by default ([#28](https://github.com/catalystcommunity/chart-platform-services/issues/28)) ([bc8b440](https://github.com/catalystcommunity/chart-platform-services/commit/bc8b4409aeeb13da52227a2ecfddc3c24cfa3bfb))
+* Added fusion auth and postgres for fusion auth to the chart ([#6](https://github.com/catalystcommunity/chart-platform-services/issues/6)) ([e457b99](https://github.com/catalystcommunity/chart-platform-services/commit/e457b998f2247a1409e0b34768358cd9dd51ffc5))
+* base64 encode secrets in grafana auth template ([#23](https://github.com/catalystcommunity/chart-platform-services/issues/23)) ([fdfa191](https://github.com/catalystcommunity/chart-platform-services/commit/fdfa191816f90dab758c1433ab294e1d5d74bab2))
+* change loki release name to match helm chart ([#24](https://github.com/catalystcommunity/chart-platform-services/issues/24)) ([6fdcdc5](https://github.com/catalystcommunity/chart-platform-services/commit/6fdcdc5f75a0314e9525d77624b38369e6b8fc0e))
+* cortex/loki auth secret namespace ([#20](https://github.com/catalystcommunity/chart-platform-services/issues/20)) ([eef2b81](https://github.com/catalystcommunity/chart-platform-services/commit/eef2b81bb1a8d735f4f1ef550d7887062f136285))
+* dashboard panels for cortex memcached ([#34](https://github.com/catalystcommunity/chart-platform-services/issues/34)) ([6f68fdd](https://github.com/catalystcommunity/chart-platform-services/commit/6f68fdddfbbc7a7cddc79c15611dfc33ada3e30a))
+* Default metrics-server apiService.create to true ([#15](https://github.com/catalystcommunity/chart-platform-services/issues/15)) ([23b12ce](https://github.com/catalystcommunity/chart-platform-services/commit/23b12ce992cf71d6e6aad887d2449eaf2785326e))
+* Default to not creating resources that would rotate certificates. ([#10](https://github.com/catalystcommunity/chart-platform-services/issues/10)) ([0d1a8cf](https://github.com/catalystcommunity/chart-platform-services/commit/0d1a8cf7998f83165ade3798563207470ed03dfa))
+* Disable sentry by default, default organizations to empty, fix wildcard cert configuration ([#2](https://github.com/catalystcommunity/chart-platform-services/issues/2)) ([126372b](https://github.com/catalystcommunity/chart-platform-services/commit/126372b61b5456110dd53d05c4e0950213d15726))
+* enable cortex ingester statefulSet by default ([#32](https://github.com/catalystcommunity/chart-platform-services/issues/32)) ([d4cd2e3](https://github.com/catalystcommunity/chart-platform-services/commit/d4cd2e363e39e33c09d18e79d06fcc9f3ae8fdca))
+* enable metrics in contour ([#17](https://github.com/catalystcommunity/chart-platform-services/issues/17)) ([50c832e](https://github.com/catalystcommunity/chart-platform-services/commit/50c832e24af2988865195123b5a44546cd48b97b))
+* enable retention on the loki compactor component ([#42](https://github.com/catalystcommunity/chart-platform-services/issues/42)) ([bef3357](https://github.com/catalystcommunity/chart-platform-services/commit/bef335726d6d0966168b2f5d3cd642857cb50939))
+* grafana datasource value reference ([#19](https://github.com/catalystcommunity/chart-platform-services/issues/19)) ([0264a06](https://github.com/catalystcommunity/chart-platform-services/commit/0264a066504ef910b5ce81e28d0155bb6e139d19))
+* increase loki gateway's default client max body size ([#26](https://github.com/catalystcommunity/chart-platform-services/issues/26)) ([72fc52f](https://github.com/catalystcommunity/chart-platform-services/commit/72fc52f7169463b15283798483c58d6a2528095f))
+* Initial commit ([#1](https://github.com/catalystcommunity/chart-platform-services/issues/1)) ([d80e5ca](https://github.com/catalystcommunity/chart-platform-services/commit/d80e5ca9a340b55b15f745dbdc098f621599ba82))
+* Linkerd uses helm template commands to generate certs. This happens on every sync, so it goes into a loop. This commit adds the necessary ignore differences specification to avoid an out of sync loop. ([#11](https://github.com/catalystcommunity/chart-platform-services/issues/11)) ([865e29b](https://github.com/catalystcommunity/chart-platform-services/commit/865e29b5316a8247bd72fcdd913410d2f31dd15d))
+* match aws default for volumeBindingMode ([#16](https://github.com/catalystcommunity/chart-platform-services/issues/16)) ([ed75766](https://github.com/catalystcommunity/chart-platform-services/commit/ed757662151a7815cf0e8ab32b7175bc6e3f4494))
+* **norelease:** allow merge commit for merging alpha to main ([#46](https://github.com/catalystcommunity/chart-platform-services/issues/46)) ([4a7bbf5](https://github.com/catalystcommunity/chart-platform-services/commit/4a7bbf5ca70c33cb7fb51802a7b248ee6d6b38b5))
+* Release ([90f4355](https://github.com/catalystcommunity/chart-platform-services/commit/90f4355140e9aa118d328e8a0978c9aaa88207a2))
+* Remove cert-manager dns secret, fix solvers config. Solvers should be yaml, not a string. ([#3](https://github.com/catalystcommunity/chart-platform-services/issues/3)) ([904012b](https://github.com/catalystcommunity/chart-platform-services/commit/904012bd0b1dcfa4f2da32fd89ef7cf162f1aa71))
+* remove configuration for cortex query scheduler ([#33](https://github.com/catalystcommunity/chart-platform-services/issues/33)) ([10e9765](https://github.com/catalystcommunity/chart-platform-services/commit/10e9765eeba3da7f078f7095e995bcf08c67b160))
+* remove htpasswd generation for grafana datasource access ([#36](https://github.com/catalystcommunity/chart-platform-services/issues/36)) ([474a38c](https://github.com/catalystcommunity/chart-platform-services/commit/474a38c8d7c7cec1777a674087be360b70ed3857))
+* Remove trustanchor.crt value in favor of existing chart value named identityTrustAnchorsPEM. ([#5](https://github.com/catalystcommunity/chart-platform-services/issues/5)) ([46d7ddc](https://github.com/catalystcommunity/chart-platform-services/commit/46d7ddcb3cd253a1eeaaebdb0245f864595b22ac))
+* rename cortex/loki dashboards to organize better with mixin ([#29](https://github.com/catalystcommunity/chart-platform-services/issues/29)) ([8193aa6](https://github.com/catalystcommunity/chart-platform-services/commit/8193aa60cb9c8664836bb0c0d9a4bcef9e79c0ea))
+* Update contour chart version ([#31](https://github.com/catalystcommunity/chart-platform-services/issues/31)) ([0401076](https://github.com/catalystcommunity/chart-platform-services/commit/040107611423dcf1f7191f96db4cc506a089e974))
+* upgrade loki helm chart, remove bug workaround ([#40](https://github.com/catalystcommunity/chart-platform-services/issues/40)) ([e49a5c7](https://github.com/catalystcommunity/chart-platform-services/commit/e49a5c71a9fdb871c082ccae99a6036c73b24e9f))
+* Use pipes to insert cert data as a multiline string ([#8](https://github.com/catalystcommunity/chart-platform-services/issues/8)) ([9f51f99](https://github.com/catalystcommunity/chart-platform-services/commit/9f51f99c0baa5da40d39d39c24accb9977c54138))
+* Use stringData for cert pem because the linkerd chart requires it as a string for a configmap, but we need it in a secret for the trust anchor ([#9](https://github.com/catalystcommunity/chart-platform-services/issues/9)) ([e0605c3](https://github.com/catalystcommunity/chart-platform-services/commit/e0605c387b37f175813d88337eab37d0af79e389))
+* Use stringData not data, the cert and key should no longer be base64 encoded ([#7](https://github.com/catalystcommunity/chart-platform-services/issues/7)) ([ee37b80](https://github.com/catalystcommunity/chart-platform-services/commit/ee37b80f9f6ede27a9850641e0cf5b48fcfb2d4d))
 
 
 ### Features
 
-* add a generic grpc service dashboard ([#43](https://github.com/catalystsquad/chart-platform-services/issues/43)) ([6821209](https://github.com/catalystsquad/chart-platform-services/commit/68212098cf5b0547f16abf83743ea8c482d55479))
-* add cluster autoscaler ([#4](https://github.com/catalystsquad/chart-platform-services/issues/4)) ([e83f1d1](https://github.com/catalystsquad/chart-platform-services/commit/e83f1d1db208bcd77c54de70344c07c1ba5eef76))
-* add grafana datasource authentication ([#21](https://github.com/catalystsquad/chart-platform-services/issues/21)) ([d117f90](https://github.com/catalystsquad/chart-platform-services/commit/d117f90bd533de88df52f749cd07c079af0b3ed7))
-* add kubernetes mixing dashboards ([#25](https://github.com/catalystsquad/chart-platform-services/issues/25)) ([ac1f001](https://github.com/catalystsquad/chart-platform-services/commit/ac1f001e07c3dfe8751a20f6b57a8e2831bcd21d)), closes [/github.com/prometheus-operator/kube-prometheus/blob/d6083dcb2d2a36a08e6ec80bd0e21323361ec000/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet#L11-L26](https://github.com//github.com/prometheus-operator/kube-prometheus/blob/d6083dcb2d2a36a08e6ec80bd0e21323361ec000/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet/issues/L11-L26)
-* add prometheus blackbox exporter dashboard ([#38](https://github.com/catalystsquad/chart-platform-services/issues/38)) ([55b1d38](https://github.com/catalystsquad/chart-platform-services/commit/55b1d3808ba897b131f606b1a39461c75d71f0d1))
-* add prometheus blackbox exporter helm chart ([#37](https://github.com/catalystsquad/chart-platform-services/issues/37)) ([32da1cf](https://github.com/catalystsquad/chart-platform-services/commit/32da1cf1364371c9c34684ce6e0dd1cfef1b9880))
-* add promtail ([#27](https://github.com/catalystsquad/chart-platform-services/issues/27)) ([35dec8b](https://github.com/catalystsquad/chart-platform-services/commit/35dec8b35cb328161aba9515df081c0cb4ff55a2))
-* add velero with initial values ([#39](https://github.com/catalystsquad/chart-platform-services/issues/39)) ([66e004c](https://github.com/catalystsquad/chart-platform-services/commit/66e004c5714f8d26eaca553e244d0738c86d4e6b))
-* allow for extra sidecar datasources in grafana chart ([#41](https://github.com/catalystsquad/chart-platform-services/issues/41)) ([1655faa](https://github.com/catalystsquad/chart-platform-services/commit/1655faa39659c855c022ff0a133d729b6288c057))
-* always redirect http to https on fusionauth ingress object ([#44](https://github.com/catalystsquad/chart-platform-services/issues/44)) ([ff67136](https://github.com/catalystsquad/chart-platform-services/commit/ff67136f0be6ed3027c406a93d18b82c4d319d2a))
-* initial observability stack ([#18](https://github.com/catalystsquad/chart-platform-services/issues/18)) ([d864f5e](https://github.com/catalystsquad/chart-platform-services/commit/d864f5e80d7873973ca3687ddfc377ea1dabd8d8))
+* add a generic grpc service dashboard ([#43](https://github.com/catalystcommunity/chart-platform-services/issues/43)) ([6821209](https://github.com/catalystcommunity/chart-platform-services/commit/68212098cf5b0547f16abf83743ea8c482d55479))
+* add cluster autoscaler ([#4](https://github.com/catalystcommunity/chart-platform-services/issues/4)) ([e83f1d1](https://github.com/catalystcommunity/chart-platform-services/commit/e83f1d1db208bcd77c54de70344c07c1ba5eef76))
+* add grafana datasource authentication ([#21](https://github.com/catalystcommunity/chart-platform-services/issues/21)) ([d117f90](https://github.com/catalystcommunity/chart-platform-services/commit/d117f90bd533de88df52f749cd07c079af0b3ed7))
+* add kubernetes mixing dashboards ([#25](https://github.com/catalystcommunity/chart-platform-services/issues/25)) ([ac1f001](https://github.com/catalystcommunity/chart-platform-services/commit/ac1f001e07c3dfe8751a20f6b57a8e2831bcd21d)), closes [/github.com/prometheus-operator/kube-prometheus/blob/d6083dcb2d2a36a08e6ec80bd0e21323361ec000/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet#L11-L26](https://github.com//github.com/prometheus-operator/kube-prometheus/blob/d6083dcb2d2a36a08e6ec80bd0e21323361ec000/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet/issues/L11-L26)
+* add prometheus blackbox exporter dashboard ([#38](https://github.com/catalystcommunity/chart-platform-services/issues/38)) ([55b1d38](https://github.com/catalystcommunity/chart-platform-services/commit/55b1d3808ba897b131f606b1a39461c75d71f0d1))
+* add prometheus blackbox exporter helm chart ([#37](https://github.com/catalystcommunity/chart-platform-services/issues/37)) ([32da1cf](https://github.com/catalystcommunity/chart-platform-services/commit/32da1cf1364371c9c34684ce6e0dd1cfef1b9880))
+* add promtail ([#27](https://github.com/catalystcommunity/chart-platform-services/issues/27)) ([35dec8b](https://github.com/catalystcommunity/chart-platform-services/commit/35dec8b35cb328161aba9515df081c0cb4ff55a2))
+* add velero with initial values ([#39](https://github.com/catalystcommunity/chart-platform-services/issues/39)) ([66e004c](https://github.com/catalystcommunity/chart-platform-services/commit/66e004c5714f8d26eaca553e244d0738c86d4e6b))
+* allow for extra sidecar datasources in grafana chart ([#41](https://github.com/catalystcommunity/chart-platform-services/issues/41)) ([1655faa](https://github.com/catalystcommunity/chart-platform-services/commit/1655faa39659c855c022ff0a133d729b6288c057))
+* always redirect http to https on fusionauth ingress object ([#44](https://github.com/catalystcommunity/chart-platform-services/issues/44)) ([ff67136](https://github.com/catalystcommunity/chart-platform-services/commit/ff67136f0be6ed3027c406a93d18b82c4d319d2a))
+* initial observability stack ([#18](https://github.com/catalystcommunity/chart-platform-services/issues/18)) ([d864f5e](https://github.com/catalystcommunity/chart-platform-services/commit/d864f5e80d7873973ca3687ddfc377ea1dabd8d8))
 
-# [1.0.0-alpha.43](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.42...v1.0.0-alpha.43) (2022-08-11)
+# [1.0.0-alpha.43](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.42...v1.0.0-alpha.43) (2022-08-11)
 
 
 ### Bug Fixes
 
-* **norelease:** allow merge commit for merging alpha to main ([#46](https://github.com/catalystsquad/chart-platform-services/issues/46)) ([4a7bbf5](https://github.com/catalystsquad/chart-platform-services/commit/4a7bbf5ca70c33cb7fb51802a7b248ee6d6b38b5))
+* **norelease:** allow merge commit for merging alpha to main ([#46](https://github.com/catalystcommunity/chart-platform-services/issues/46)) ([4a7bbf5](https://github.com/catalystcommunity/chart-platform-services/commit/4a7bbf5ca70c33cb7fb51802a7b248ee6d6b38b5))
 
 
 ### Features
 
-* always redirect http to https on fusionauth ingress object ([#44](https://github.com/catalystsquad/chart-platform-services/issues/44)) ([ff67136](https://github.com/catalystsquad/chart-platform-services/commit/ff67136f0be6ed3027c406a93d18b82c4d319d2a))
+* always redirect http to https on fusionauth ingress object ([#44](https://github.com/catalystcommunity/chart-platform-services/issues/44)) ([ff67136](https://github.com/catalystcommunity/chart-platform-services/commit/ff67136f0be6ed3027c406a93d18b82c4d319d2a))
 
-# [1.0.0-alpha.42](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.41...v1.0.0-alpha.42) (2022-07-26)
-
-
-### Features
-
-* add a generic grpc service dashboard ([#43](https://github.com/catalystsquad/chart-platform-services/issues/43)) ([6821209](https://github.com/catalystsquad/chart-platform-services/commit/68212098cf5b0547f16abf83743ea8c482d55479))
-
-# [1.0.0-alpha.41](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.40...v1.0.0-alpha.41) (2022-07-26)
-
-
-### Bug Fixes
-
-* enable retention on the loki compactor component ([#42](https://github.com/catalystsquad/chart-platform-services/issues/42)) ([bef3357](https://github.com/catalystsquad/chart-platform-services/commit/bef335726d6d0966168b2f5d3cd642857cb50939))
-
-# [1.0.0-alpha.40](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.39...v1.0.0-alpha.40) (2022-07-11)
+# [1.0.0-alpha.42](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.41...v1.0.0-alpha.42) (2022-07-26)
 
 
 ### Features
 
-* allow for extra sidecar datasources in grafana chart ([#41](https://github.com/catalystsquad/chart-platform-services/issues/41)) ([1655faa](https://github.com/catalystsquad/chart-platform-services/commit/1655faa39659c855c022ff0a133d729b6288c057))
+* add a generic grpc service dashboard ([#43](https://github.com/catalystcommunity/chart-platform-services/issues/43)) ([6821209](https://github.com/catalystcommunity/chart-platform-services/commit/68212098cf5b0547f16abf83743ea8c482d55479))
 
-# [1.0.0-alpha.39](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.38...v1.0.0-alpha.39) (2022-04-26)
+# [1.0.0-alpha.41](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.40...v1.0.0-alpha.41) (2022-07-26)
 
 
 ### Bug Fixes
 
-* upgrade loki helm chart, remove bug workaround ([#40](https://github.com/catalystsquad/chart-platform-services/issues/40)) ([e49a5c7](https://github.com/catalystsquad/chart-platform-services/commit/e49a5c71a9fdb871c082ccae99a6036c73b24e9f))
+* enable retention on the loki compactor component ([#42](https://github.com/catalystcommunity/chart-platform-services/issues/42)) ([bef3357](https://github.com/catalystcommunity/chart-platform-services/commit/bef335726d6d0966168b2f5d3cd642857cb50939))
 
-# [1.0.0-alpha.38](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.37...v1.0.0-alpha.38) (2022-04-26)
+# [1.0.0-alpha.40](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.39...v1.0.0-alpha.40) (2022-07-11)
 
 
 ### Features
 
-* add velero with initial values ([#39](https://github.com/catalystsquad/chart-platform-services/issues/39)) ([66e004c](https://github.com/catalystsquad/chart-platform-services/commit/66e004c5714f8d26eaca553e244d0738c86d4e6b))
+* allow for extra sidecar datasources in grafana chart ([#41](https://github.com/catalystcommunity/chart-platform-services/issues/41)) ([1655faa](https://github.com/catalystcommunity/chart-platform-services/commit/1655faa39659c855c022ff0a133d729b6288c057))
 
-# [1.0.0-alpha.37](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.36...v1.0.0-alpha.37) (2022-04-04)
+# [1.0.0-alpha.39](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.38...v1.0.0-alpha.39) (2022-04-26)
+
+
+### Bug Fixes
+
+* upgrade loki helm chart, remove bug workaround ([#40](https://github.com/catalystcommunity/chart-platform-services/issues/40)) ([e49a5c7](https://github.com/catalystcommunity/chart-platform-services/commit/e49a5c71a9fdb871c082ccae99a6036c73b24e9f))
+
+# [1.0.0-alpha.38](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.37...v1.0.0-alpha.38) (2022-04-26)
 
 
 ### Features
 
-* add prometheus blackbox exporter dashboard ([#38](https://github.com/catalystsquad/chart-platform-services/issues/38)) ([55b1d38](https://github.com/catalystsquad/chart-platform-services/commit/55b1d3808ba897b131f606b1a39461c75d71f0d1))
+* add velero with initial values ([#39](https://github.com/catalystcommunity/chart-platform-services/issues/39)) ([66e004c](https://github.com/catalystcommunity/chart-platform-services/commit/66e004c5714f8d26eaca553e244d0738c86d4e6b))
 
-# [1.0.0-alpha.36](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.35...v1.0.0-alpha.36) (2022-04-01)
-
-
-### Features
-
-* add prometheus blackbox exporter helm chart ([#37](https://github.com/catalystsquad/chart-platform-services/issues/37)) ([32da1cf](https://github.com/catalystsquad/chart-platform-services/commit/32da1cf1364371c9c34684ce6e0dd1cfef1b9880))
-
-# [1.0.0-alpha.35](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.34...v1.0.0-alpha.35) (2022-04-01)
-
-
-### Bug Fixes
-
-* add http metric dashboard panels for cortex ([#35](https://github.com/catalystsquad/chart-platform-services/issues/35)) ([9d16235](https://github.com/catalystsquad/chart-platform-services/commit/9d16235f13a40e050bea5a4446f4df20aa5092cf))
-
-# [1.0.0-alpha.34](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.33...v1.0.0-alpha.34) (2022-04-01)
-
-
-### Bug Fixes
-
-* remove htpasswd generation for grafana datasource access ([#36](https://github.com/catalystsquad/chart-platform-services/issues/36)) ([474a38c](https://github.com/catalystsquad/chart-platform-services/commit/474a38c8d7c7cec1777a674087be360b70ed3857))
-
-# [1.0.0-alpha.33](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.32...v1.0.0-alpha.33) (2022-03-31)
-
-
-### Bug Fixes
-
-* dashboard panels for cortex memcached ([#34](https://github.com/catalystsquad/chart-platform-services/issues/34)) ([6f68fdd](https://github.com/catalystsquad/chart-platform-services/commit/6f68fdddfbbc7a7cddc79c15611dfc33ada3e30a))
-
-# [1.0.0-alpha.32](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.31...v1.0.0-alpha.32) (2022-03-31)
-
-
-### Bug Fixes
-
-* remove configuration for cortex query scheduler ([#33](https://github.com/catalystsquad/chart-platform-services/issues/33)) ([10e9765](https://github.com/catalystsquad/chart-platform-services/commit/10e9765eeba3da7f078f7095e995bcf08c67b160))
-
-# [1.0.0-alpha.31](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.30...v1.0.0-alpha.31) (2022-03-31)
-
-
-### Bug Fixes
-
-* enable cortex ingester statefulSet by default ([#32](https://github.com/catalystsquad/chart-platform-services/issues/32)) ([d4cd2e3](https://github.com/catalystsquad/chart-platform-services/commit/d4cd2e363e39e33c09d18e79d06fcc9f3ae8fdca))
-
-# [1.0.0-alpha.30](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.29...v1.0.0-alpha.30) (2022-03-31)
-
-
-### Bug Fixes
-
-* Update contour chart version ([#31](https://github.com/catalystsquad/chart-platform-services/issues/31)) ([0401076](https://github.com/catalystsquad/chart-platform-services/commit/040107611423dcf1f7191f96db4cc506a089e974))
-
-# [1.0.0-alpha.29](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.28...v1.0.0-alpha.29) (2022-03-31)
-
-
-### Bug Fixes
-
-* add index gateway panel's to loki dashboard ([#30](https://github.com/catalystsquad/chart-platform-services/issues/30)) ([bb4ad1e](https://github.com/catalystsquad/chart-platform-services/commit/bb4ad1e954100f0de27589ffdd267e2472919865))
-
-# [1.0.0-alpha.28](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.27...v1.0.0-alpha.28) (2022-03-30)
-
-
-### Bug Fixes
-
-* rename cortex/loki dashboards to organize better with mixin ([#29](https://github.com/catalystsquad/chart-platform-services/issues/29)) ([8193aa6](https://github.com/catalystsquad/chart-platform-services/commit/8193aa60cb9c8664836bb0c0d9a4bcef9e79c0ea))
-
-# [1.0.0-alpha.27](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.26...v1.0.0-alpha.27) (2022-03-30)
-
-
-### Bug Fixes
-
-* Add self signed certificate issuer, enabled by default ([#28](https://github.com/catalystsquad/chart-platform-services/issues/28)) ([bc8b440](https://github.com/catalystsquad/chart-platform-services/commit/bc8b4409aeeb13da52227a2ecfddc3c24cfa3bfb))
-
-# [1.0.0-alpha.26](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.25...v1.0.0-alpha.26) (2022-03-30)
+# [1.0.0-alpha.37](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.36...v1.0.0-alpha.37) (2022-04-04)
 
 
 ### Features
 
-* add promtail ([#27](https://github.com/catalystsquad/chart-platform-services/issues/27)) ([35dec8b](https://github.com/catalystsquad/chart-platform-services/commit/35dec8b35cb328161aba9515df081c0cb4ff55a2))
+* add prometheus blackbox exporter dashboard ([#38](https://github.com/catalystcommunity/chart-platform-services/issues/38)) ([55b1d38](https://github.com/catalystcommunity/chart-platform-services/commit/55b1d3808ba897b131f606b1a39461c75d71f0d1))
 
-# [1.0.0-alpha.25](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.24...v1.0.0-alpha.25) (2022-03-30)
-
-
-### Bug Fixes
-
-* increase loki gateway's default client max body size ([#26](https://github.com/catalystsquad/chart-platform-services/issues/26)) ([72fc52f](https://github.com/catalystsquad/chart-platform-services/commit/72fc52f7169463b15283798483c58d6a2528095f))
-
-# [1.0.0-alpha.24](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.23...v1.0.0-alpha.24) (2022-03-29)
+# [1.0.0-alpha.36](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.35...v1.0.0-alpha.36) (2022-04-01)
 
 
 ### Features
 
-* add kubernetes mixing dashboards ([#25](https://github.com/catalystsquad/chart-platform-services/issues/25)) ([ac1f001](https://github.com/catalystsquad/chart-platform-services/commit/ac1f001e07c3dfe8751a20f6b57a8e2831bcd21d)), closes [/github.com/prometheus-operator/kube-prometheus/blob/d6083dcb2d2a36a08e6ec80bd0e21323361ec000/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet#L11-L26](https://github.com//github.com/prometheus-operator/kube-prometheus/blob/d6083dcb2d2a36a08e6ec80bd0e21323361ec000/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet/issues/L11-L26)
+* add prometheus blackbox exporter helm chart ([#37](https://github.com/catalystcommunity/chart-platform-services/issues/37)) ([32da1cf](https://github.com/catalystcommunity/chart-platform-services/commit/32da1cf1364371c9c34684ce6e0dd1cfef1b9880))
 
-# [1.0.0-alpha.23](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.22...v1.0.0-alpha.23) (2022-03-29)
-
-
-### Bug Fixes
-
-* change loki release name to match helm chart ([#24](https://github.com/catalystsquad/chart-platform-services/issues/24)) ([6fdcdc5](https://github.com/catalystsquad/chart-platform-services/commit/6fdcdc5f75a0314e9525d77624b38369e6b8fc0e))
-
-# [1.0.0-alpha.22](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.21...v1.0.0-alpha.22) (2022-03-29)
+# [1.0.0-alpha.35](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.34...v1.0.0-alpha.35) (2022-04-01)
 
 
 ### Bug Fixes
 
-* base64 encode secrets in grafana auth template ([#23](https://github.com/catalystsquad/chart-platform-services/issues/23)) ([fdfa191](https://github.com/catalystsquad/chart-platform-services/commit/fdfa191816f90dab758c1433ab294e1d5d74bab2))
+* add http metric dashboard panels for cortex ([#35](https://github.com/catalystcommunity/chart-platform-services/issues/35)) ([9d16235](https://github.com/catalystcommunity/chart-platform-services/commit/9d16235f13a40e050bea5a4446f4df20aa5092cf))
 
-# [1.0.0-alpha.21](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.20...v1.0.0-alpha.21) (2022-03-29)
+# [1.0.0-alpha.34](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.33...v1.0.0-alpha.34) (2022-04-01)
 
 
 ### Bug Fixes
 
-* add datasource auth environment variable secret ([#22](https://github.com/catalystsquad/chart-platform-services/issues/22)) ([4aa6bcf](https://github.com/catalystsquad/chart-platform-services/commit/4aa6bcf3d8f8393df372f9fca90c963b31ec31eb))
+* remove htpasswd generation for grafana datasource access ([#36](https://github.com/catalystcommunity/chart-platform-services/issues/36)) ([474a38c](https://github.com/catalystcommunity/chart-platform-services/commit/474a38c8d7c7cec1777a674087be360b70ed3857))
 
-# [1.0.0-alpha.20](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.19...v1.0.0-alpha.20) (2022-03-29)
+# [1.0.0-alpha.33](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.32...v1.0.0-alpha.33) (2022-03-31)
+
+
+### Bug Fixes
+
+* dashboard panels for cortex memcached ([#34](https://github.com/catalystcommunity/chart-platform-services/issues/34)) ([6f68fdd](https://github.com/catalystcommunity/chart-platform-services/commit/6f68fdddfbbc7a7cddc79c15611dfc33ada3e30a))
+
+# [1.0.0-alpha.32](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.31...v1.0.0-alpha.32) (2022-03-31)
+
+
+### Bug Fixes
+
+* remove configuration for cortex query scheduler ([#33](https://github.com/catalystcommunity/chart-platform-services/issues/33)) ([10e9765](https://github.com/catalystcommunity/chart-platform-services/commit/10e9765eeba3da7f078f7095e995bcf08c67b160))
+
+# [1.0.0-alpha.31](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.30...v1.0.0-alpha.31) (2022-03-31)
+
+
+### Bug Fixes
+
+* enable cortex ingester statefulSet by default ([#32](https://github.com/catalystcommunity/chart-platform-services/issues/32)) ([d4cd2e3](https://github.com/catalystcommunity/chart-platform-services/commit/d4cd2e363e39e33c09d18e79d06fcc9f3ae8fdca))
+
+# [1.0.0-alpha.30](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.29...v1.0.0-alpha.30) (2022-03-31)
+
+
+### Bug Fixes
+
+* Update contour chart version ([#31](https://github.com/catalystcommunity/chart-platform-services/issues/31)) ([0401076](https://github.com/catalystcommunity/chart-platform-services/commit/040107611423dcf1f7191f96db4cc506a089e974))
+
+# [1.0.0-alpha.29](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.28...v1.0.0-alpha.29) (2022-03-31)
+
+
+### Bug Fixes
+
+* add index gateway panel's to loki dashboard ([#30](https://github.com/catalystcommunity/chart-platform-services/issues/30)) ([bb4ad1e](https://github.com/catalystcommunity/chart-platform-services/commit/bb4ad1e954100f0de27589ffdd267e2472919865))
+
+# [1.0.0-alpha.28](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.27...v1.0.0-alpha.28) (2022-03-30)
+
+
+### Bug Fixes
+
+* rename cortex/loki dashboards to organize better with mixin ([#29](https://github.com/catalystcommunity/chart-platform-services/issues/29)) ([8193aa6](https://github.com/catalystcommunity/chart-platform-services/commit/8193aa60cb9c8664836bb0c0d9a4bcef9e79c0ea))
+
+# [1.0.0-alpha.27](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.26...v1.0.0-alpha.27) (2022-03-30)
+
+
+### Bug Fixes
+
+* Add self signed certificate issuer, enabled by default ([#28](https://github.com/catalystcommunity/chart-platform-services/issues/28)) ([bc8b440](https://github.com/catalystcommunity/chart-platform-services/commit/bc8b4409aeeb13da52227a2ecfddc3c24cfa3bfb))
+
+# [1.0.0-alpha.26](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.25...v1.0.0-alpha.26) (2022-03-30)
 
 
 ### Features
 
-* add grafana datasource authentication ([#21](https://github.com/catalystsquad/chart-platform-services/issues/21)) ([d117f90](https://github.com/catalystsquad/chart-platform-services/commit/d117f90bd533de88df52f749cd07c079af0b3ed7))
+* add promtail ([#27](https://github.com/catalystcommunity/chart-platform-services/issues/27)) ([35dec8b](https://github.com/catalystcommunity/chart-platform-services/commit/35dec8b35cb328161aba9515df081c0cb4ff55a2))
 
-# [1.0.0-alpha.19](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.18...v1.0.0-alpha.19) (2022-03-28)
-
-
-### Bug Fixes
-
-* cortex/loki auth secret namespace ([#20](https://github.com/catalystsquad/chart-platform-services/issues/20)) ([eef2b81](https://github.com/catalystsquad/chart-platform-services/commit/eef2b81bb1a8d735f4f1ef550d7887062f136285))
-
-# [1.0.0-alpha.18](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.17...v1.0.0-alpha.18) (2022-03-28)
+# [1.0.0-alpha.25](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.24...v1.0.0-alpha.25) (2022-03-30)
 
 
 ### Bug Fixes
 
-* grafana datasource value reference ([#19](https://github.com/catalystsquad/chart-platform-services/issues/19)) ([0264a06](https://github.com/catalystsquad/chart-platform-services/commit/0264a066504ef910b5ce81e28d0155bb6e139d19))
+* increase loki gateway's default client max body size ([#26](https://github.com/catalystcommunity/chart-platform-services/issues/26)) ([72fc52f](https://github.com/catalystcommunity/chart-platform-services/commit/72fc52f7169463b15283798483c58d6a2528095f))
 
-# [1.0.0-alpha.17](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.16...v1.0.0-alpha.17) (2022-03-28)
+# [1.0.0-alpha.24](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.23...v1.0.0-alpha.24) (2022-03-29)
 
 
 ### Features
 
-* initial observability stack ([#18](https://github.com/catalystsquad/chart-platform-services/issues/18)) ([d864f5e](https://github.com/catalystsquad/chart-platform-services/commit/d864f5e80d7873973ca3687ddfc377ea1dabd8d8))
+* add kubernetes mixing dashboards ([#25](https://github.com/catalystcommunity/chart-platform-services/issues/25)) ([ac1f001](https://github.com/catalystcommunity/chart-platform-services/commit/ac1f001e07c3dfe8751a20f6b57a8e2831bcd21d)), closes [/github.com/prometheus-operator/kube-prometheus/blob/d6083dcb2d2a36a08e6ec80bd0e21323361ec000/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet#L11-L26](https://github.com//github.com/prometheus-operator/kube-prometheus/blob/d6083dcb2d2a36a08e6ec80bd0e21323361ec000/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet/issues/L11-L26)
 
-# [1.0.0-alpha.16](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.15...v1.0.0-alpha.16) (2022-03-25)
-
-
-### Bug Fixes
-
-* enable metrics in contour ([#17](https://github.com/catalystsquad/chart-platform-services/issues/17)) ([50c832e](https://github.com/catalystsquad/chart-platform-services/commit/50c832e24af2988865195123b5a44546cd48b97b))
-
-# [1.0.0-alpha.15](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.14...v1.0.0-alpha.15) (2022-03-23)
+# [1.0.0-alpha.23](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.22...v1.0.0-alpha.23) (2022-03-29)
 
 
 ### Bug Fixes
 
-* match aws default for volumeBindingMode ([#16](https://github.com/catalystsquad/chart-platform-services/issues/16)) ([ed75766](https://github.com/catalystsquad/chart-platform-services/commit/ed757662151a7815cf0e8ab32b7175bc6e3f4494))
+* change loki release name to match helm chart ([#24](https://github.com/catalystcommunity/chart-platform-services/issues/24)) ([6fdcdc5](https://github.com/catalystcommunity/chart-platform-services/commit/6fdcdc5f75a0314e9525d77624b38369e6b8fc0e))
 
-# [1.0.0-alpha.14](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.13...v1.0.0-alpha.14) (2022-03-21)
-
-
-### Bug Fixes
-
-* Default metrics-server apiService.create to true ([#15](https://github.com/catalystsquad/chart-platform-services/issues/15)) ([23b12ce](https://github.com/catalystsquad/chart-platform-services/commit/23b12ce992cf71d6e6aad887d2449eaf2785326e))
-
-# [1.0.0-alpha.13](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.12...v1.0.0-alpha.13) (2022-03-21)
+# [1.0.0-alpha.22](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.21...v1.0.0-alpha.22) (2022-03-29)
 
 
 ### Bug Fixes
 
-* Add resource requests to linkerd proxy, and contour envoy shutdown manager. Without these HPAs don't work. ([#14](https://github.com/catalystsquad/chart-platform-services/issues/14)) ([a2c0a0a](https://github.com/catalystsquad/chart-platform-services/commit/a2c0a0a75bb1191cb64c1ffb9e242a08fb96b0e3))
+* base64 encode secrets in grafana auth template ([#23](https://github.com/catalystcommunity/chart-platform-services/issues/23)) ([fdfa191](https://github.com/catalystcommunity/chart-platform-services/commit/fdfa191816f90dab758c1433ab294e1d5d74bab2))
 
-# [1.0.0-alpha.12](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.11...v1.0.0-alpha.12) (2022-03-18)
-
-
-### Bug Fixes
-
-* Add empty group so argo will stop diffing. ([#13](https://github.com/catalystsquad/chart-platform-services/issues/13)) ([b9c8f25](https://github.com/catalystsquad/chart-platform-services/commit/b9c8f2587aa4a27b1917f9b5e18e357e017b2c84))
-
-# [1.0.0-alpha.11](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.10...v1.0.0-alpha.11) (2022-03-18)
+# [1.0.0-alpha.21](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.20...v1.0.0-alpha.21) (2022-03-29)
 
 
 ### Bug Fixes
 
-* Add ignore differences to linkerd-jaeger and linkerd-viz ([#12](https://github.com/catalystsquad/chart-platform-services/issues/12)) ([0294c3e](https://github.com/catalystsquad/chart-platform-services/commit/0294c3eb56976a90b52ad02f167025396b839b47))
+* add datasource auth environment variable secret ([#22](https://github.com/catalystcommunity/chart-platform-services/issues/22)) ([4aa6bcf](https://github.com/catalystcommunity/chart-platform-services/commit/4aa6bcf3d8f8393df372f9fca90c963b31ec31eb))
 
-# [1.0.0-alpha.10](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.9...v1.0.0-alpha.10) (2022-03-18)
-
-
-### Bug Fixes
-
-* Linkerd uses helm template commands to generate certs. This happens on every sync, so it goes into a loop. This commit adds the necessary ignore differences specification to avoid an out of sync loop. ([#11](https://github.com/catalystsquad/chart-platform-services/issues/11)) ([865e29b](https://github.com/catalystsquad/chart-platform-services/commit/865e29b5316a8247bd72fcdd913410d2f31dd15d))
-
-# [1.0.0-alpha.9](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.8...v1.0.0-alpha.9) (2022-03-17)
-
-
-### Bug Fixes
-
-* Default to not creating resources that would rotate certificates. ([#10](https://github.com/catalystsquad/chart-platform-services/issues/10)) ([0d1a8cf](https://github.com/catalystsquad/chart-platform-services/commit/0d1a8cf7998f83165ade3798563207470ed03dfa))
-
-# [1.0.0-alpha.8](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.7...v1.0.0-alpha.8) (2022-03-17)
-
-
-### Bug Fixes
-
-* Use stringData for cert pem because the linkerd chart requires it as a string for a configmap, but we need it in a secret for the trust anchor ([#9](https://github.com/catalystsquad/chart-platform-services/issues/9)) ([e0605c3](https://github.com/catalystsquad/chart-platform-services/commit/e0605c387b37f175813d88337eab37d0af79e389))
-
-# [1.0.0-alpha.7](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.6...v1.0.0-alpha.7) (2022-03-16)
-
-
-### Bug Fixes
-
-* Use pipes to insert cert data as a multiline string ([#8](https://github.com/catalystsquad/chart-platform-services/issues/8)) ([9f51f99](https://github.com/catalystsquad/chart-platform-services/commit/9f51f99c0baa5da40d39d39c24accb9977c54138))
-
-# [1.0.0-alpha.6](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.5...v1.0.0-alpha.6) (2022-03-16)
-
-
-### Bug Fixes
-
-* Use stringData not data, the cert and key should no longer be base64 encoded ([#7](https://github.com/catalystsquad/chart-platform-services/issues/7)) ([ee37b80](https://github.com/catalystsquad/chart-platform-services/commit/ee37b80f9f6ede27a9850641e0cf5b48fcfb2d4d))
-
-# [1.0.0-alpha.5](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.4...v1.0.0-alpha.5) (2022-03-16)
-
-
-### Bug Fixes
-
-* Added fusion auth and postgres for fusion auth to the chart ([#6](https://github.com/catalystsquad/chart-platform-services/issues/6)) ([e457b99](https://github.com/catalystsquad/chart-platform-services/commit/e457b998f2247a1409e0b34768358cd9dd51ffc5))
-* Remove trustanchor.crt value in favor of existing chart value named identityTrustAnchorsPEM. ([#5](https://github.com/catalystsquad/chart-platform-services/issues/5)) ([46d7ddc](https://github.com/catalystsquad/chart-platform-services/commit/46d7ddcb3cd253a1eeaaebdb0245f864595b22ac))
-
-# [1.0.0-alpha.4](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.3...v1.0.0-alpha.4) (2022-03-15)
+# [1.0.0-alpha.20](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.19...v1.0.0-alpha.20) (2022-03-29)
 
 
 ### Features
 
-* add cluster autoscaler ([#4](https://github.com/catalystsquad/chart-platform-services/issues/4)) ([e83f1d1](https://github.com/catalystsquad/chart-platform-services/commit/e83f1d1db208bcd77c54de70344c07c1ba5eef76))
+* add grafana datasource authentication ([#21](https://github.com/catalystcommunity/chart-platform-services/issues/21)) ([d117f90](https://github.com/catalystcommunity/chart-platform-services/commit/d117f90bd533de88df52f749cd07c079af0b3ed7))
 
-# [1.0.0-alpha.3](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.2...v1.0.0-alpha.3) (2022-03-14)
-
-
-### Bug Fixes
-
-* Remove cert-manager dns secret, fix solvers config. Solvers should be yaml, not a string. ([#3](https://github.com/catalystsquad/chart-platform-services/issues/3)) ([904012b](https://github.com/catalystsquad/chart-platform-services/commit/904012bd0b1dcfa4f2da32fd89ef7cf162f1aa71))
-
-# [1.0.0-alpha.2](https://github.com/catalystsquad/chart-platform-services/compare/v1.0.0-alpha.1...v1.0.0-alpha.2) (2022-03-14)
+# [1.0.0-alpha.19](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.18...v1.0.0-alpha.19) (2022-03-28)
 
 
 ### Bug Fixes
 
-* Disable sentry by default, default organizations to empty, fix wildcard cert configuration ([#2](https://github.com/catalystsquad/chart-platform-services/issues/2)) ([126372b](https://github.com/catalystsquad/chart-platform-services/commit/126372b61b5456110dd53d05c4e0950213d15726))
+* cortex/loki auth secret namespace ([#20](https://github.com/catalystcommunity/chart-platform-services/issues/20)) ([eef2b81](https://github.com/catalystcommunity/chart-platform-services/commit/eef2b81bb1a8d735f4f1ef550d7887062f136285))
+
+# [1.0.0-alpha.18](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.17...v1.0.0-alpha.18) (2022-03-28)
+
+
+### Bug Fixes
+
+* grafana datasource value reference ([#19](https://github.com/catalystcommunity/chart-platform-services/issues/19)) ([0264a06](https://github.com/catalystcommunity/chart-platform-services/commit/0264a066504ef910b5ce81e28d0155bb6e139d19))
+
+# [1.0.0-alpha.17](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.16...v1.0.0-alpha.17) (2022-03-28)
+
+
+### Features
+
+* initial observability stack ([#18](https://github.com/catalystcommunity/chart-platform-services/issues/18)) ([d864f5e](https://github.com/catalystcommunity/chart-platform-services/commit/d864f5e80d7873973ca3687ddfc377ea1dabd8d8))
+
+# [1.0.0-alpha.16](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.15...v1.0.0-alpha.16) (2022-03-25)
+
+
+### Bug Fixes
+
+* enable metrics in contour ([#17](https://github.com/catalystcommunity/chart-platform-services/issues/17)) ([50c832e](https://github.com/catalystcommunity/chart-platform-services/commit/50c832e24af2988865195123b5a44546cd48b97b))
+
+# [1.0.0-alpha.15](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.14...v1.0.0-alpha.15) (2022-03-23)
+
+
+### Bug Fixes
+
+* match aws default for volumeBindingMode ([#16](https://github.com/catalystcommunity/chart-platform-services/issues/16)) ([ed75766](https://github.com/catalystcommunity/chart-platform-services/commit/ed757662151a7815cf0e8ab32b7175bc6e3f4494))
+
+# [1.0.0-alpha.14](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.13...v1.0.0-alpha.14) (2022-03-21)
+
+
+### Bug Fixes
+
+* Default metrics-server apiService.create to true ([#15](https://github.com/catalystcommunity/chart-platform-services/issues/15)) ([23b12ce](https://github.com/catalystcommunity/chart-platform-services/commit/23b12ce992cf71d6e6aad887d2449eaf2785326e))
+
+# [1.0.0-alpha.13](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.12...v1.0.0-alpha.13) (2022-03-21)
+
+
+### Bug Fixes
+
+* Add resource requests to linkerd proxy, and contour envoy shutdown manager. Without these HPAs don't work. ([#14](https://github.com/catalystcommunity/chart-platform-services/issues/14)) ([a2c0a0a](https://github.com/catalystcommunity/chart-platform-services/commit/a2c0a0a75bb1191cb64c1ffb9e242a08fb96b0e3))
+
+# [1.0.0-alpha.12](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.11...v1.0.0-alpha.12) (2022-03-18)
+
+
+### Bug Fixes
+
+* Add empty group so argo will stop diffing. ([#13](https://github.com/catalystcommunity/chart-platform-services/issues/13)) ([b9c8f25](https://github.com/catalystcommunity/chart-platform-services/commit/b9c8f2587aa4a27b1917f9b5e18e357e017b2c84))
+
+# [1.0.0-alpha.11](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.10...v1.0.0-alpha.11) (2022-03-18)
+
+
+### Bug Fixes
+
+* Add ignore differences to linkerd-jaeger and linkerd-viz ([#12](https://github.com/catalystcommunity/chart-platform-services/issues/12)) ([0294c3e](https://github.com/catalystcommunity/chart-platform-services/commit/0294c3eb56976a90b52ad02f167025396b839b47))
+
+# [1.0.0-alpha.10](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.9...v1.0.0-alpha.10) (2022-03-18)
+
+
+### Bug Fixes
+
+* Linkerd uses helm template commands to generate certs. This happens on every sync, so it goes into a loop. This commit adds the necessary ignore differences specification to avoid an out of sync loop. ([#11](https://github.com/catalystcommunity/chart-platform-services/issues/11)) ([865e29b](https://github.com/catalystcommunity/chart-platform-services/commit/865e29b5316a8247bd72fcdd913410d2f31dd15d))
+
+# [1.0.0-alpha.9](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.8...v1.0.0-alpha.9) (2022-03-17)
+
+
+### Bug Fixes
+
+* Default to not creating resources that would rotate certificates. ([#10](https://github.com/catalystcommunity/chart-platform-services/issues/10)) ([0d1a8cf](https://github.com/catalystcommunity/chart-platform-services/commit/0d1a8cf7998f83165ade3798563207470ed03dfa))
+
+# [1.0.0-alpha.8](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.7...v1.0.0-alpha.8) (2022-03-17)
+
+
+### Bug Fixes
+
+* Use stringData for cert pem because the linkerd chart requires it as a string for a configmap, but we need it in a secret for the trust anchor ([#9](https://github.com/catalystcommunity/chart-platform-services/issues/9)) ([e0605c3](https://github.com/catalystcommunity/chart-platform-services/commit/e0605c387b37f175813d88337eab37d0af79e389))
+
+# [1.0.0-alpha.7](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.6...v1.0.0-alpha.7) (2022-03-16)
+
+
+### Bug Fixes
+
+* Use pipes to insert cert data as a multiline string ([#8](https://github.com/catalystcommunity/chart-platform-services/issues/8)) ([9f51f99](https://github.com/catalystcommunity/chart-platform-services/commit/9f51f99c0baa5da40d39d39c24accb9977c54138))
+
+# [1.0.0-alpha.6](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.5...v1.0.0-alpha.6) (2022-03-16)
+
+
+### Bug Fixes
+
+* Use stringData not data, the cert and key should no longer be base64 encoded ([#7](https://github.com/catalystcommunity/chart-platform-services/issues/7)) ([ee37b80](https://github.com/catalystcommunity/chart-platform-services/commit/ee37b80f9f6ede27a9850641e0cf5b48fcfb2d4d))
+
+# [1.0.0-alpha.5](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.4...v1.0.0-alpha.5) (2022-03-16)
+
+
+### Bug Fixes
+
+* Added fusion auth and postgres for fusion auth to the chart ([#6](https://github.com/catalystcommunity/chart-platform-services/issues/6)) ([e457b99](https://github.com/catalystcommunity/chart-platform-services/commit/e457b998f2247a1409e0b34768358cd9dd51ffc5))
+* Remove trustanchor.crt value in favor of existing chart value named identityTrustAnchorsPEM. ([#5](https://github.com/catalystcommunity/chart-platform-services/issues/5)) ([46d7ddc](https://github.com/catalystcommunity/chart-platform-services/commit/46d7ddcb3cd253a1eeaaebdb0245f864595b22ac))
+
+# [1.0.0-alpha.4](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.3...v1.0.0-alpha.4) (2022-03-15)
+
+
+### Features
+
+* add cluster autoscaler ([#4](https://github.com/catalystcommunity/chart-platform-services/issues/4)) ([e83f1d1](https://github.com/catalystcommunity/chart-platform-services/commit/e83f1d1db208bcd77c54de70344c07c1ba5eef76))
+
+# [1.0.0-alpha.3](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.2...v1.0.0-alpha.3) (2022-03-14)
+
+
+### Bug Fixes
+
+* Remove cert-manager dns secret, fix solvers config. Solvers should be yaml, not a string. ([#3](https://github.com/catalystcommunity/chart-platform-services/issues/3)) ([904012b](https://github.com/catalystcommunity/chart-platform-services/commit/904012bd0b1dcfa4f2da32fd89ef7cf162f1aa71))
+
+# [1.0.0-alpha.2](https://github.com/catalystcommunity/chart-platform-services/compare/v1.0.0-alpha.1...v1.0.0-alpha.2) (2022-03-14)
+
+
+### Bug Fixes
+
+* Disable sentry by default, default organizations to empty, fix wildcard cert configuration ([#2](https://github.com/catalystcommunity/chart-platform-services/issues/2)) ([126372b](https://github.com/catalystcommunity/chart-platform-services/commit/126372b61b5456110dd53d05c4e0950213d15726))
 
 # 1.0.0-alpha.1 (2022-03-14)
 
 
 ### Bug Fixes
 
-* Initial commit ([#1](https://github.com/catalystsquad/chart-platform-services/issues/1)) ([d80e5ca](https://github.com/catalystsquad/chart-platform-services/commit/d80e5ca9a340b55b15f745dbdc098f621599ba82))
+* Initial commit ([#1](https://github.com/catalystcommunity/chart-platform-services/issues/1)) ([d80e5ca](https://github.com/catalystcommunity/chart-platform-services/commit/d80e5ca9a340b55b15f745dbdc098f621599ba82))

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: platform-services
 description: Deploys commonly used kubernetes services as argocd applications, along with any dependent secrets, certificates, etc.
 type: application
-version: 2.1.1
+version: 2.2.0-alpha.1
 appVersion: "0.0.0"

--- a/chart/templates/aws-ecr-creds.yaml
+++ b/chart/templates/aws-ecr-creds.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://raw.githubusercontent.com/catalystsquad/charts/main
+    repoURL: https://raw.githubusercontent.com/catalystcommunity/charts/main
     chart: aws-ecr-creds
     targetRevision: {{ .Values.awsEcrCreds.targetRevision | quote }}
     helm:

--- a/chart/templates/contour.yaml
+++ b/chart/templates/contour.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://charts.bitnami.com/bitnami
+    repoURL: registry-1.docker.io/bitnamicharts/contour
     chart: contour
     targetRevision: {{ .Values.contour.targetRevision | quote }}
     helm:


### PR DESCRIPTION
- aws-ecr-creds is in catalystcommunity now
- contour has moved to an oci chart registry instead of the bitnami classic registry