### PR TITLE
fix: bitnami repoURL

### DIFF
--- a/chart/templates/contour.yaml
+++ b/chart/templates/contour.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: registry-1.docker.io/bitnamicharts/contour
+    repoURL: registry-1.docker.io/bitnamicharts
     chart: contour
     targetRevision: {{ .Values.contour.targetRevision | quote }}
     helm:


### PR DESCRIPTION
change the bitnami repo to not include `/contour`

fixes: https://github.com/catalystcommunity/chart-platform-services/issues/74